### PR TITLE
Framerate Independent Movement

### DIFF
--- a/Assets/Scripts/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Controllers/PlayerController.cs
@@ -31,7 +31,7 @@ namespace MMC
             movementDelta = new Vector2();
         }
 
-        void Update()
+        void FixedUpdate()
         {
             if (bIsMoving)
             {


### PR DESCRIPTION
> :warning: NOTE: any important notes that should be read before reviewing this PR go here

### Problem:

The movement was dependent on the framerate of the system, so my computer running around 144 fps meant the character was zooming around the level.

### Solution:

<!-- solution explanation -->

All I had to do is change `Update` to `FixedUpdate`. The latter update function is framerate independent and is the obvious solution.

### Additional Notes:

Anything in the future that requires movement or anything physics-based should be done in `FixedUpdate`!

### Testing:

Play the level and verify the movement.
